### PR TITLE
Add examples/multiregion/ multi region example

### DIFF
--- a/examples/multiregion/README.md
+++ b/examples/multiregion/README.md
@@ -1,0 +1,5 @@
+Multi region example
+===
+
+This example uses multiple calls to the `52_regional_multinic` module to
+illustrate how to create multiple clusters in multiple regions.

--- a/examples/multiregion/main.tf
+++ b/examples/multiregion/main.tf
@@ -1,0 +1,93 @@
+# Copyright 2020 Open Infrastructure Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "num_instances" {
+  description = "Set to 0 to reduce costs when not actively developing."
+  type        = number
+  default     = 1
+}
+
+variable "preemptible" {
+  description = "Allows instance to be preempted. This defaults to false. See https://cloud.google.com/compute/docs/instances/preemptible"
+  type        = bool
+  default     = true
+}
+
+locals {
+  project_id = "multinic-networks-18d1"
+
+  nic0_network = "main"
+  nic1_network = "transit"
+}
+
+## NOTE on cidr ranges
+# nic0_cidrs means the CIDR ranges for each traffic routes via (egress) nic0.
+# nic0 is "eastbound" toward the main Shared VPC.
+#
+# nic1_cidrs means the CIDR ranges for each traffic routes via (egress) nic1.
+# nic1 is "westbound" toward the Transit VPC
+
+# Manage the regional MIG formation
+module "multinic-us-west1" {
+  source = "../../modules/52_regional_multinic"
+
+  num_instances = var.num_instances
+  preemptible   = var.preemptible
+
+  project_id  = local.project_id
+  region      = "us-west1"
+
+  nic0_network = local.nic0_network
+  nic0_project = local.project_id
+  # Subnet nic0 is attached to.
+  nic0_subnet  = "main-bridge"
+  # Eastbound cidrs close to this region are routed through this multinic.
+  nic0_cidrs   = ["10.32.0.0/20", "10.33.0.0/20"]
+
+  nic1_network = local.nic1_network
+  nic1_project = local.project_id
+  # Subnet nic1 is attached to.
+  nic1_subnet  = "transit-bridge"
+  # Westbound cidrs close to this region are routed through this multinic.
+  nic1_cidrs   = ["10.36.0.0/20", "10.37.0.0/20"]
+
+  service_account_email = "multinic@${local.project_id}.iam.gserviceaccount.com"
+}
+
+# Manage the regional MIG formation
+module "multinic-us-west2" {
+  source = "../../modules/52_regional_multinic"
+
+  num_instances = var.num_instances
+  preemptible   = var.preemptible
+
+  project_id  = local.project_id
+  region      = "us-west2"
+
+  nic0_network = local.nic0_network
+  nic0_project = local.project_id
+  # Subnet nic0 is attached to.
+  nic0_subnet  = "main-bridge2"
+  # Eastbound cidrs close to this region are routed through this multinic.
+  nic0_cidrs   = ["10.34.0.0/20", "10.40.0.0/20"]
+
+  nic1_network = local.nic1_network
+  nic1_project = local.project_id
+  # Subnet nic1 is attached to.
+  nic1_subnet  = "transit-bridge2"
+  # Westbound cidrs close to this region are routed through this multinic.
+  nic1_cidrs   = ["10.38.0.0/20", "10.41.0.0/20"]
+
+  service_account_email = "multinic@${local.project_id}.iam.gserviceaccount.com"
+}

--- a/examples/networksetup/main.tf
+++ b/examples/networksetup/main.tf
@@ -43,6 +43,7 @@ module "main-vpc" {
     general = { ip_cidr_range = "10.32.0.0/20", region = local.region },
     bridge  = { ip_cidr_range = "10.33.0.0/20", region = local.region },
     remote  = { ip_cidr_range = "10.34.0.0/20", region = "us-west2" },
+    bridge2  = { ip_cidr_range = "10.40.0.0/20", region = "us-west2" },
   }
   project_id = local.project_id
   region     = local.region
@@ -58,6 +59,7 @@ module "transit-vpc" {
     general = { ip_cidr_range = "10.36.0.0/20", region = local.region },
     bridge = { ip_cidr_range = "10.37.0.0/20", region = local.region },
     remote  = { ip_cidr_range = "10.38.0.0/20", region = "us-west2" },
+    bridge2 = { ip_cidr_range = "10.41.0.0/20", region = "us-west2" },
   }
   project_id   = local.project_id
   region       = local.region

--- a/modules/52_regional_multinic/main.tf
+++ b/modules/52_regional_multinic/main.tf
@@ -1,0 +1,250 @@
+# Copyright 2020 Google, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+
+  nic0_network = "main"
+  nic0_subnet  = "main-bridge"
+  nic1_network = "transit"
+  nic1_subnet  = "transit-bridge"
+}
+
+# Manage the regional MIG formation
+module "multinic-a" {
+  source = "../50_compute"
+
+  num_instances = var.num_instances
+  preemptible   = var.preemptible
+  autoscale     = var.num_instances == 0 ? false : true
+
+  project_id  = var.project_id
+  name_prefix = "multinic-${var.region}-a"
+  region      = var.region
+  zone        = "${var.region}-a"
+
+  nic0_project = var.project_id
+  nic0_network = var.nic0_network
+  nic0_subnet  = var.nic0_subnet
+
+  nic1_project = var.project_id
+  nic1_network = var.nic1_network
+  nic1_subnet  = var.nic1_subnet
+
+  hc_self_link          = google_compute_health_check.multinic-health.self_link
+  service_account_email = var.service_account_email
+}
+
+module "multinic-b" {
+  source = "../50_compute"
+
+  num_instances = var.num_instances
+  preemptible   = var.preemptible
+  autoscale     = var.num_instances == 0 ? false : true
+
+  project_id  = var.project_id
+  name_prefix = "multinic-${var.region}-b"
+  region      = var.region
+  zone        = "${var.region}-b"
+
+  nic0_project = var.project_id
+  nic0_network = var.nic0_network
+  nic0_subnet  = var.nic0_subnet
+
+  nic1_project = var.project_id
+  nic1_network = var.nic1_network
+  nic1_subnet  = var.nic1_subnet
+
+  hc_self_link          = google_compute_health_check.multinic-health.self_link
+  service_account_email = var.service_account_email
+}
+
+module "multinic-c" {
+  source = "../50_compute"
+
+  num_instances = var.num_instances
+  preemptible   = var.preemptible
+  autoscale     = var.num_instances == 0 ? false : true
+
+  project_id  = var.project_id
+  name_prefix = "multinic-${var.region}-c"
+  region      = var.region
+  zone        = "${var.region}-c"
+
+  nic0_project = var.project_id
+  nic0_network = var.nic0_network
+  nic0_subnet  = var.nic0_subnet
+
+  nic1_project = var.project_id
+  nic1_network = var.nic1_network
+  nic1_subnet  = var.nic1_subnet
+
+  hc_self_link          = google_compute_health_check.multinic-health.self_link
+  service_account_email = var.service_account_email
+}
+
+# The "health" health check is used for auto-healing with the MIG.  The
+# timeouts are longer to reduce the risk of removing an otherwise healthy
+# instance.
+resource google_compute_health_check "multinic-health" {
+  project = var.project_id
+  name    = "multinic-health-${var.region}"
+
+  check_interval_sec  = 10
+  timeout_sec         = 5
+  healthy_threshold   = 2
+  unhealthy_threshold = 3
+
+  http_health_check {
+    port         = 9000
+    request_path = "/status.json"
+  }
+}
+
+# The "traffic" health check is used by the load balancer.  The instance will
+# be taken out of service if the health check fails and other instances have
+# passing traffic checks.  This check is more agressive so that the a
+# preemptible instance is able to take itself out of rotation within the 30
+# second window provided for shutdown.
+resource google_compute_health_check "multinic-traffic" {
+  project = var.project_id
+  name    = "multinic-traffic-${var.region}"
+
+  check_interval_sec  = 3
+  timeout_sec         = 2
+  healthy_threshold   = 2
+  unhealthy_threshold = 2
+
+  http_health_check {
+    port         = 9001
+    request_path = "/status.json"
+  }
+}
+
+resource "google_compute_region_backend_service" "multinic-main" {
+  provider = google-beta
+  project  = var.project_id
+
+  name                  = "multinic-main-${var.region}"
+  network               = var.nic0_network
+  region                = var.region
+  load_balancing_scheme = "INTERNAL"
+
+  backend {
+    group = module.multinic-a.instance_group
+  }
+
+  backend {
+    group = module.multinic-b.instance_group
+  }
+
+  backend {
+    group = module.multinic-c.instance_group
+  }
+
+  # Note this is the traffic health check, not the auto-healing check
+  health_checks = [google_compute_health_check.multinic-traffic.id]
+}
+
+resource "google_compute_region_backend_service" "multinic-transit" {
+  provider = google-beta
+  project  = var.project_id
+
+  name                  = "multinic-transit-${var.region}"
+  network               = var.nic1_network
+  region                = var.region
+  load_balancing_scheme = "INTERNAL"
+
+  backend {
+    group = module.multinic-a.instance_group
+  }
+
+  backend {
+    group = module.multinic-b.instance_group
+  }
+
+  backend {
+    group = module.multinic-c.instance_group
+  }
+
+  # Note this is the traffic health check, not the auto-healing check
+  health_checks = [google_compute_health_check.multinic-traffic.id]
+}
+
+# Reserve an address so we have a well known address to configure for policy routing.
+resource "google_compute_address" "main" {
+  name         = "multinic-fwd-main-${var.region}"
+  project      = var.project_id
+  region       = var.region
+  subnetwork   = var.nic0_subnet
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "transit" {
+  name         = "multinic-fwd-transit-${var.region}"
+  project      = var.project_id
+  region       = var.region
+  subnetwork   = var.nic1_subnet
+  address_type = "INTERNAL"
+}
+
+resource google_compute_forwarding_rule "main" {
+  name    = "multinic-main-${var.region}"
+  project = var.project_id
+  region  = var.region
+
+  ip_address      = google_compute_address.main.address
+  backend_service = google_compute_region_backend_service.multinic-main.id
+  network         = var.nic0_network
+  subnetwork      = var.nic0_subnet
+
+  load_balancing_scheme = "INTERNAL"
+  all_ports             = true
+  allow_global_access   = true
+}
+
+resource google_compute_forwarding_rule "transit" {
+  name    = "multinic-transit-${var.region}"
+  project = var.project_id
+  region  = var.region
+
+  ip_address      = google_compute_address.transit.address
+  backend_service = google_compute_region_backend_service.multinic-transit.id
+  network         = var.nic1_network
+  subnetwork      = var.nic1_subnet
+
+  load_balancing_scheme = "INTERNAL"
+  all_ports             = true
+  allow_global_access   = true
+}
+
+// Route resources
+resource google_compute_route "main" {
+  for_each     = toset(var.nic1_cidrs)
+  name         = "multinic-main-${var.region}-${substr(sha1(each.value), 0, 6)}"
+  project      = var.project_id
+  network      = var.nic0_network
+  dest_range   = each.value
+  priority     = 900
+  next_hop_ilb = google_compute_forwarding_rule.main.self_link
+}
+
+resource google_compute_route "transit" {
+  for_each     = toset(var.nic0_cidrs)
+  name         = "multinic-transit-${var.region}-${substr(sha1(each.value), 0, 6)}"
+  project      = var.project_id
+  network      = var.nic1_network
+  dest_range   = each.value
+  priority     = 900
+  next_hop_ilb = google_compute_forwarding_rule.transit.self_link
+}

--- a/modules/52_regional_multinic/variables.tf
+++ b/modules/52_regional_multinic/variables.tf
@@ -1,0 +1,82 @@
+# Copyright 2020 Google, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The project ID containing the managed resources"
+  type        = string
+}
+
+variable "region" {
+  description = "The region containing the managed resources"
+  type        = string
+}
+
+variable "num_instances" {
+  description = "Set to 0 to reduce costs when not actively developing."
+  type        = number
+  default     = 0
+}
+
+variable "preemptible" {
+  description = "Allows instance to be preempted. This defaults to false. See https://cloud.google.com/compute/docs/instances/preemptible"
+  type        = bool
+  default     = false
+}
+
+variable "nic0_network" {
+  description = "The VPC network nic0 is attached to."
+  type        = string
+}
+
+variable "nic0_subnet" {
+  description = "The name of the subnet the nic0 interface of multinic instance will use.  Do not specify as a fully qualified name."
+  type        = string
+}
+
+variable "nic0_project" {
+  description = "The project id which hosts the shared vpc network."
+  type        = string
+}
+
+variable "nic0_cidrs" {
+  description = "A list of subnets in cidr notation, traffic destined for these subnets will route out nic0.  Used to configure routes. (e.g. 10.16.0.0/20)"
+  type        = list(string)
+  default     = []
+}
+
+variable "nic1_network" {
+  description = "The VPC network nic1 is attached to."
+  type        = string
+}
+
+variable "nic1_subnet" {
+  description = "The name of the subnet the nic1 interface of multinic instance will use.  Do not specify as a fully qualified name."
+  type        = string
+}
+
+variable "nic1_project" {
+  description = "The project id which hosts the shared vpc network."
+  type        = string
+}
+
+variable "nic1_cidrs" {
+  description = "A list of subnets in cidr notation, traffic destined for these subnets will route out nic1.  Used to configure routes. (e.g. 10.16.0.0/20)"
+  type        = list(string)
+  default     = []
+}
+
+variable "service_account_email" {
+  description = "The service account bound to the bridge VM instances.  Must have permission to create Route resources in both the app and core VPC networks."
+  type        = string
+}


### PR DESCRIPTION
This patch adds an example of how to create multiple multinic clusters in multiple regions.  A new module, 52_regional_multinic encapsulates each zonal multinic instance.  The inputs to this new module are the cidr ranges to route through the region, the region, and the values necessary to manage the multinic instances themselves.

Resolves: https://github.com/openinfrastructure/terraform-google-multinic/issues/18