### PR TITLE
Manage multinic instance groups in all zones in the region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+v2.0.0 - 2020-09-29
+===
+
+ * Fix [issue/20][issue20] `modules/52_regional_multinic` now deploys instance
+   groups to all available zones in the specified region.  Fixes error
+   deploying to us-east1 and europe-west1 where there is no `a` zone.
+ * Note, resources will be destroyed and re-created.  The inputs to
+   `52_regional_multinic` have *not* changed relative to v1.4.0.  The `zone`
+   input to `50_compute` is replaced by `zones`.
+
 v1.4.0 - 2020-09-28
 ===
 
@@ -65,3 +75,4 @@ v0.4.3
 
 [issue10]: https://github.com/openinfrastructure/terraform-google-multinic/issues/10
 [guest76]: https://github.com/GoogleCloudPlatform/guest-agent/issues/76
+[issue20]: https://github.com/openinfrastructure/terraform-google-multinic/issues/20

--- a/modules/50_compute/outputs.tf
+++ b/modules/50_compute/outputs.tf
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-output "instance_group" {
-  description = "The instance group intended for use with a google_compute_region_backend_service resource"
-  value       = google_compute_instance_group_manager.multinic.instance_group
+output "instance_groups" {
+  description = "The instance groups intended for use with a google_compute_region_backend_service resource"
+  value       = { for k,v in google_compute_instance_group_manager.multinic : k => v.instance_group }
 }

--- a/modules/50_compute/variables.tf
+++ b/modules/50_compute/variables.tf
@@ -27,9 +27,9 @@ variable "region" {
   type        = string
 }
 
-variable "zone" {
-  description = "The zone containing the managed resources"
-  type        = string
+variable "zones" {
+  description = "The zones containing the managed resources, for example ['us-west1-a', 'us-west1-b', 'us-west1-c']"
+  type        = list(string)
 }
 
 variable "service_account_email" {


### PR DESCRIPTION
Without this patch the `52_regional_multinic` module makes the blind
assumption zones a, b, and c exist in the region.  This is a problem for
us-east1 and europe-west1 which do not have zone a.

This patch fixes the problem by changing 50_compute's zone input
parameter to a list of zone name strings, `zones`.  Similarly,
`52_regional_multinic` is updated to automatically determine all
available zones in the region and create multinic groups in each zone.

Resolves: https://github.com/openinfrastructure/terraform-google-multinic/issues/20