### PR TITLE
Pin the os image used for all multinic instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v3.1.0 - 2020-10-02
+===
+
+ * Pin the os image to a specific version to ensure consistent behavior when
+   scaling in, scaling out, auto-healing, and across multiple terraform apply
+   runs.
+ * Replaced the `os_image` input var with `image_project`, `image_family`, and
+   `image_name`.
+
 v3.0.0 - 2020-09-30
 ===
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ instances in multiple zones within a single region.
     auto-healing.
  5. 2 ILB forwarding rules, one for each VPC.
 
+OS Images
+===
+
+Version 3.1.0 and later of this module pins the OS image used for multinic
+instances to a specific value.  This ensures the same image is used as
+instances scale in, scale out, and are auto-healed.   In addition, multiple
+runs of terraform will use the same image specified by the `image_name` input
+value.
+
+See [Deploying the Latest
+Image](https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#deploying-the-latest-image)
+for additional information.
+
 Requirements
 ===
 

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_compute_image" "img" {
+  project = var.image_project
+  name    = var.image_name == "" ? null : var.image_name
+  family  = var.image_name == "" ? var.image_family : null
+}
+
 locals {
   tags = concat(list("multinic-router"), var.tags)
   # Unique suffix for regional resources
@@ -52,9 +58,9 @@ resource google_compute_instance_template "multinic" {
   }
 
   disk {
+    source_image = data.google_compute_image.img.self_link
     auto_delete  = true
     boot         = true
-    source_image = var.os_image
     type         = "PERSISTENT"
     disk_size_gb = var.disk_size_gb
   }

--- a/modules/50_compute/variables.tf
+++ b/modules/50_compute/variables.tf
@@ -38,10 +38,22 @@ variable "service_account_email" {
   type        = string
 }
 
-variable "os_image" {
-  description = "The os_image used with the MIG instance template"
+variable "image_project" {
+  description = "The image project used with the MIG instance template"
   type        = string
-  default     = "centos-cloud/centos-8"
+  default     = "centos-cloud"
+}
+
+variable "image_name" {
+  description = "The image name used with the MIG instance template.  If the value is the empty string, image_family is used instead."
+  type        = string
+  default     = "centos-8-v20200910"
+}
+
+variable "image_family" {
+  description = "Configures templates to use the latest non-deprecated image in the family at the point Terraform apply is run.  Used only if image_name is empty."
+  type        = string
+  default     = "centos-8"
 }
 
 variable "nic0_network" {

--- a/modules/52_regional_multinic/main.tf
+++ b/modules/52_regional_multinic/main.tf
@@ -27,9 +27,12 @@ locals {
 module "multinic" {
   source = "../50_compute"
 
+  image_project = var.image_project
+  image_name    = var.image_name
+  image_family  = var.image_family
+  machine_type  = var.machine_type
   num_instances = var.num_instances
   preemptible   = var.preemptible
-  autoscale     = var.num_instances == 0 ? false : true
 
   project_id  = var.project_id
   name_prefix = var.name_prefix
@@ -43,6 +46,10 @@ module "multinic" {
   nic1_project = var.project_id
   nic1_network = var.nic1_network
   nic1_subnet  = var.nic1_subnet
+
+  autoscale          = var.autoscale
+  utilization_target = var.utilization_target
+  max_replicas       = var.max_replicas
 
   hc_self_link          = google_compute_health_check.multinic-health.self_link
   service_account_email = var.service_account_email

--- a/modules/52_regional_multinic/variables.tf
+++ b/modules/52_regional_multinic/variables.tf
@@ -40,6 +40,30 @@ variable "num_instances" {
   default     = 0
 }
 
+variable "machine_type" {
+  description = "The machine type of each IP Router Bridge instance.  Check the table for Maximum egress bandwidth - https://cloud.google.com/compute/docs/machine-types"
+  type        = string
+  default     = "n1-highcpu-2"
+}
+
+variable "image_project" {
+  description = "The image project used with the MIG instance template"
+  type        = string
+  default     = "centos-cloud"
+}
+
+variable "image_name" {
+  description = "The image name used with the MIG instance template.  If the value is the empty string, image_family is used instead."
+  type        = string
+  default     = "centos-8-v20200910"
+}
+
+variable "image_family" {
+  description = "Configures templates to use the latest non-deprecated image in the family at the point Terraform apply is run.  Used only if image_name is empty."
+  type        = string
+  default     = "centos-8"
+}
+
 variable "preemptible" {
   description = "Allows instance to be preempted. This defaults to false. See https://cloud.google.com/compute/docs/instances/preemptible"
   type        = bool
@@ -91,4 +115,32 @@ variable "nic1_cidrs" {
 variable "service_account_email" {
   description = "The service account bound to the bridge VM instances.  Must have permission to create Route resources in both the app and core VPC networks."
   type        = string
+}
+
+variable "autoscale" {
+  description = "Enable autoscaling default configuration, .  For advanced configuration, set to false and manage your own google_compute_autoscaler resource with target set this module's instance_group.id output value."
+  type        = bool
+  default     = true
+}
+
+variable "utilization_target" {
+  description = "The CPU utilization_target for the Autoscaler.  A n1-highcpu-2 instance sending at 10Gbps has CPU utilization of 22-24%."
+  type        = number
+  default     = 0.2 # 20% when using CPU Utilization
+  # default   = 939524096 # 70% of 10Gbps when using `instance/network/sent_bytes_count`
+  # default   = 161061273 # 60% of 2Gbps when using `instance/network/sent_bytes_count`
+}
+
+variable "max_replicas" {
+  description = "The maximum number of instances when the Autoscaler scales out"
+  type        = number
+  default     = 4
+}
+
+variable "labels" {
+  description = "Labels to apply to the compute instance resources managed by this module"
+  type        = map
+  default     = {
+    role = "multinic-router"
+  }
 }


### PR DESCRIPTION
In order to avoid the risk of upstream changes to the os image
family causing multinic routing to break.  The image value will remain
constant through multiple terraform runs by default.

When using image family, the latest non deprecated image will be
determined when terraform apply runs.  The instance group manager will
ensure all instances use the same version.

This patch also passes through the autoscale related variables from the
52_regional_multinic module to the underlying 50_compute module.

See [Deploying the Latest
Image](https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#deploying-the-latest-image)