### PR TITLE
Do not set MIG target_size when Autoscale is enabled

### DIFF
--- a/examples/compute/main.tf
+++ b/examples/compute/main.tf
@@ -32,7 +32,7 @@ variable "preemptible" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
   region     = "us-west1"
 
   # nic0's gateway routes to this netblock

--- a/examples/endpoints/main.tf
+++ b/examples/endpoints/main.tf
@@ -51,7 +51,7 @@ variable "iperf_client" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
 }
 
 # Manage the regional MIG formation

--- a/examples/multiregion/main.tf
+++ b/examples/multiregion/main.tf
@@ -25,7 +25,7 @@ variable "preemptible" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
 
   nic0_network = "main"
   nic1_network = "transit"

--- a/examples/networksetup/main.tf
+++ b/examples/networksetup/main.tf
@@ -25,12 +25,12 @@ locals {
 module "host" {
   source = "../../modules/10_project"
 
-  folder_id       = "folders/104511770867"
+  folder_id       = "folders/504963200559"
   organization    = "openinfrastructure.co"
   org_id          = "600043944461"
   project_name    = "multinic-networks"
   billing_account = "010C18-6A318B-190124"
-  iap_members     = ["group:gcp-platform-v2-admin@openinfrastructure.co"]
+  iap_members     = ["group:gcp-platform-admin@openinfrastructure.co"]
 }
 
 # Comment this out if you already have a VPC

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -98,7 +98,10 @@ resource "google_compute_instance_group_manager" "multinic" {
     min_ready_sec         = 120
   }
 
-  target_size = var.num_instances
+  # See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager#target_size
+  # This value should always be explicitly set unless this resource is attached
+  # to an autoscaler, in which case it should never be set.
+  target_size = var.autoscale ? null : var.num_instances
 
   named_port {
     name = "hc-health"


### PR DESCRIPTION
Without this patch terraform will scale down the MIG which could cause
packets to be dropped when the auto scaler has scaled the group up in
response to traffic.

This patch follows the guidlines of the [target_size][1] terraform
documentation.  "This value should always be explicitly set unless this
resource is attached to an autoscaler, in which case it should never be
set."

Resolves: #27

Example output:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.multinic.google_compute_autoscaler.multinic["us-west1-b"] will be updated in-place
  ~ resource "google_compute_autoscaler" "multinic" {
        creation_timestamp = "2020-12-23T11:35:29.284-08:00"
        id                 = "projects/multinic-networks-534d/zones/us-west1-b/autoscalers/multinic-us-west1-b"
        name               = "multinic-us-west1-b"
        project            = "multinic-networks-534d"
        self_link          = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-b/autoscalers/multinic-us-west1-b"
        target             = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-b/instanceGroupManagers/multinic-us-west1-b"
        zone               = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-b"

      ~ autoscaling_policy {
            cooldown_period = 45
            max_replicas    = 4
          ~ min_replicas    = 1 -> 2
            mode            = "ON"

            cpu_utilization {
                target = 0.2
            }
        }
    }

  # module.multinic.google_compute_autoscaler.multinic["us-west1-c"] will be updated in-place
  ~ resource "google_compute_autoscaler" "multinic" {
        creation_timestamp = "2020-12-23T11:35:29.306-08:00"
        id                 = "projects/multinic-networks-534d/zones/us-west1-c/autoscalers/multinic-us-west1-c"
        name               = "multinic-us-west1-c"
        project            = "multinic-networks-534d"
        self_link          = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-c/autoscalers/multinic-us-west1-c"
        target             = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-c/instanceGroupManagers/multinic-us-west1-c"
        zone               = "https://www.googleapis.com/compute/v1/projects/multinic-networks-534d/zones/us-west1-c"

      ~ autoscaling_policy {
            cooldown_period = 45
            max_replicas    = 4
          ~ min_replicas    = 1 -> 2
            mode            = "ON"

            cpu_utilization {
                target = 0.2
            }
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.multinic.google_compute_autoscaler.multinic["us-west1-b"]: Modifying... [id=projects/multinic-networks-534d/zones/us-west1-b/autoscalers/multinic-us-west1-b]
module.multinic.google_compute_autoscaler.multinic["us-west1-c"]: Modifying... [id=projects/multinic-networks-534d/zones/us-west1-c/autoscalers/multinic-us-west1-c]
module.multinic.google_compute_autoscaler.multinic["us-west1-c"]: Still modifying... [id=projects/multinic-networks-534d/zones/us-west1-c/autoscalers/multinic-us-west1-c, 10s elapsed]
module.multinic.google_compute_autoscaler.multinic["us-west1-b"]: Still modifying... [id=projects/multinic-networks-534d/zones/us-west1-b/autoscalers/multinic-us-west1-b, 10s elapsed]
module.multinic.google_compute_autoscaler.multinic["us-west1-c"]: Modifications complete after 12s [id=projects/multinic-networks-534d/zones/us-west1-c/autoscalers/multinic-us-west1-c]
module.multinic.google_compute_autoscaler.multinic["us-west1-b"]: Modifications complete after 13s [id=projects/multinic-networks-534d/zones/us-west1-b/autoscalers/multinic-us-west1-b]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
```

[1]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager#target_size
