### PR TITLE
Merge 2.1.1 target_size fix into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ v3.0.0 - 2020-09-30
  * Follow the process described in [UPGRADE.md](./docs/UPGRADE.md) when
    upgrading to this major version.
 
+v2.0.1 - 2020-12-23
+===
+
+ * Fix [issue/27][issue27] `target_size` should not be set with an auto scaler.
+
 v2.0.0 - 2020-09-29
 ===
 
@@ -93,3 +98,4 @@ v0.4.3
 [issue10]: https://github.com/openinfrastructure/terraform-google-multinic/issues/10
 [guest76]: https://github.com/GoogleCloudPlatform/guest-agent/issues/76
 [issue20]: https://github.com/openinfrastructure/terraform-google-multinic/issues/20
+[issue27]: https://github.com/openinfrastructure/terraform-google-multinic/issues/27

--- a/examples/compute/main.tf
+++ b/examples/compute/main.tf
@@ -32,7 +32,7 @@ variable "preemptible" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
   region     = "us-west1"
 
   # nic0's gateway routes to this netblock

--- a/examples/endpoints/main.tf
+++ b/examples/endpoints/main.tf
@@ -51,7 +51,7 @@ variable "iperf_client" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
 }
 
 # Manage the regional MIG formation

--- a/examples/multiregion/main.tf
+++ b/examples/multiregion/main.tf
@@ -25,7 +25,7 @@ variable "preemptible" {
 }
 
 locals {
-  project_id = "multinic-networks-18d1"
+  project_id = "multinic-networks-534d"
 
   nic0_network = "main"
   nic1_network = "transit"

--- a/examples/networksetup/main.tf
+++ b/examples/networksetup/main.tf
@@ -25,12 +25,12 @@ locals {
 module "host" {
   source = "../../modules/10_project"
 
-  folder_id       = "folders/104511770867"
+  folder_id       = "folders/504963200559"
   organization    = "openinfrastructure.co"
   org_id          = "600043944461"
   project_name    = "multinic-networks"
   billing_account = "010C18-6A318B-190124"
-  iap_members     = ["group:gcp-platform-v2-admin@openinfrastructure.co"]
+  iap_members     = ["group:gcp-platform-admin@openinfrastructure.co"]
 }
 
 # Comment this out if you already have a VPC

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -106,7 +106,10 @@ resource "google_compute_instance_group_manager" "multinic" {
     min_ready_sec         = 120
   }
 
-  target_size = var.num_instances
+  # See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager#target_size
+  # This value should always be explicitly set unless this resource is attached
+  # to an autoscaler, in which case it should never be set.
+  target_size = var.autoscale ? null : var.num_instances
 
   named_port {
     name = "hc-health"


### PR DESCRIPTION
Resolves: #31

- Update project_id for examples
- Do not set MIG target_size when Autoscale is enabled
- Update CHANGELOG for 2.0.1
