### PR TITLE
Modify update policy to match GKE defaults

### DIFF
--- a/examples/compute/main.tf
+++ b/examples/compute/main.tf
@@ -62,12 +62,10 @@ module "multinic" {
   nic0_network = local.nic0_network
   nic0_project = local.project_id
   nic0_subnet  = local.nic0_subnet
-  nic0_cidrs   = [local.nic0_netblock]
 
   nic1_network = local.nic1_network
   nic1_project = local.project_id
   nic1_subnet  = local.nic1_subnet
-  nic1_cidrs   = [local.nic1_netblock]
 
   hc_self_link = google_compute_health_check.multinic-health.self_link
   service_account_email = "multinic@${local.project_id}.iam.gserviceaccount.com"

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -97,8 +97,8 @@ resource "google_compute_instance_group_manager" "multinic" {
   update_policy {
     type                  = "PROACTIVE"
     minimal_action        = "REPLACE"
-    max_surge_percent     = 20
-    max_unavailable_fixed = 1
+    max_surge_fixed       = 1
+    max_unavailable_fixed = 0
     min_ready_sec         = 120
   }
 

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -30,10 +30,6 @@ module "startup-script-lib" {
 
 data "template_file" "startup-script-config" {
   template = "${file("${path.module}/templates/startup-script-config.tpl")}"
-  vars = {
-    nic0_cidrs = join(",", var.nic0_cidrs)
-    nic1_cidrs = join(",", var.nic1_cidrs)
-  }
 }
 
 resource google_compute_instance_template "multinic" {
@@ -154,14 +150,5 @@ resource "google_compute_autoscaler" "multinic" {
       # 0.2 is a good value for a n1-highcpu-2 as of 2020-09-24
       target = var.utilization_target
     }
-
-    ## See https://cloud.google.com/monitoring/api/metrics_gcp
-    # Delta count of bytes sent over the network. Sampled every 60 seconds.
-    # After sampling, data is not visible for up to 240 seconds.
-    # metric {
-    #   name   = "compute.googleapis.com/instance/network/sent_bytes_count"
-    #   target = var.utilization_target
-    #   type   = "DELTA_PER_SECOND"
-    # }
   }
 }

--- a/modules/50_compute/templates/startup-script-config.tpl
+++ b/modules/50_compute/templates/startup-script-config.tpl
@@ -11,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Comma separated list of CIDRS which nic0 is used for egress.
-NIC0_CIDRS="${nic0_cidrs}"
-# Comma separated list of CIDRS which nic1 is used for egress.
-NIC1_CIDRS="${nic1_cidrs}"

--- a/modules/50_compute/variables.tf
+++ b/modules/50_compute/variables.tf
@@ -71,12 +71,6 @@ variable "nic0_project" {
   type        = string
 }
 
-variable "nic0_cidrs" {
-  description = "A list of subnets in cidr notation, traffic destined for these subnets will route out nic0.  Used to configure routes. (e.g. 10.16.0.0/20)"
-  type        = list(string)
-  default     = []
-}
-
 variable "nic1_network" {
   description = "The VPC network nic1 is attached to."
   type        = string
@@ -95,12 +89,6 @@ variable "nic1_project" {
 variable "hc_self_link" {
   description = "The health check self link used for auto healing.  This health check may be reused with backend services."
   type        = string
-}
-
-variable "nic1_cidrs" {
-  description = "A list of subnets in cidr notation, traffic destined for these subnets will route out nic1.  Used to configure routes. (e.g. 10.16.0.0/20)"
-  type        = list(string)
-  default     = []
 }
 
 variable "machine_type" {


### PR DESCRIPTION
Without this patch the instance group update policy does not align with GKE defaults.  This patch changes the default policy to add one instance above the target instance size, wait for it to become healthy, then remove an instance from the group.

This change ensure capacity remains constant at the target level during a rolling update.

Verified:

```
gcloud compute instance-groups managed wait-until --stable multinic-v3-8ea6b9 --zone us-west1-a
Waiting for group to become stable, current operations: verifying: 1
Waiting for group to become stable, current operations: verifying: 1
Waiting for group to become stable, current operations: verifying: 1
Waiting for group to become stable, current operations: verifying: 1
Waiting for group to become stable, current operations: verifying: 1
Waiting for group to become stable
Waiting for group to become stable, current operations: deleting: 1
Waiting for group to become stable, current operations: deleting: 1
Waiting for group to become stable, current operations: deleting: 1
Group is stable
```

Resolves: #32
Resolves: #35 
