### PR TITLE
Fix Error: Invalid prefix for given prefix length

### DIFF
--- a/modules/50_compute/files/startup-multinic.sh
+++ b/modules/50_compute/files/startup-multinic.sh
@@ -221,10 +221,10 @@ configure_policy_routing() {
   netmask1="$(stdlib::metadata_get -k instance/network-interfaces/1/subnetmask)"
   gateway1="$(stdlib::metadata_get -k instance/network-interfaces/1/gateway)"
 
-  eval "$(ipcalc -p "${ip0}/${netmask0}")"
-  net0="${ip0}/${PREFIX}"
-  eval "$(ipcalc -p "${ip1}/${netmask1}")"
-  net1="${ip1}/${PREFIX}"
+  eval "$(ipcalc --network --prefix "${ip0}/${netmask0}")"
+  net0="${NETWORK}/${PREFIX}"
+  eval "$(ipcalc --network --prefix "${ip1}/${netmask1}")"
+  net1="${NETWORK}/${PREFIX}"
 
   tmpfile="$(mktemp)"
   cat <<EOF >"$tmpfile"
@@ -236,6 +236,8 @@ fi
 if ! grep -qx '11 viaeth1' /etc/iproute2/rt_tables; then
   echo "11 viaeth1" >> /etc/iproute2/rt_tables
 fi
+
+set -x
 
 ## These are essentially the same tables, just different default routes.
 # via eth0


### PR DESCRIPTION
This patch fixes the error caused by using the IP address instead of the
network address when replacing routes.  The error doesn't affect the
behavior of the system, but it is confusing and a red-herring when
troubleshooting other issues.  The `set -x` is intentionally left in to
help troubleshoot any future issues, the commands are displayed in the
console and journal in-line with the commands generating the output.

See: [Issue 28][1] for more details and debug logs.

Resolves: #28

[1]: https://github.com/openinfrastructure/terraform-google-multinic/issues/28

