### PR TITLE
(#40) Add startup_script_user input variable

### DIFF
--- a/examples/compute/main.tf
+++ b/examples/compute/main.tf
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "project_id" {
+  description = "Project ID containing managed resources"
+  type        = string
+}
+
 variable "num_instances" {
   description = "Set to 0 to reduce costs when not actively developing."
   type        = number
@@ -31,9 +36,10 @@ variable "preemptible" {
   default     = true
 }
 
-variable "project_id" {
-  description = "Project ID containing managed resources"
+variable "startup_script" {
+  description = "Startup script executed after the initilization of multinic routing.  Must be a bash script."
   type        = string
+  default     = ""
 }
 
 locals {
@@ -55,9 +61,10 @@ locals {
 module "multinic" {
   source = "../../modules/50_compute"
 
-  num_instances = var.num_instances
-  preemptible   = var.preemptible
-  autoscale     = var.num_instances == 0 ? false : true
+  num_instances  = var.num_instances
+  preemptible    = var.preemptible
+  autoscale      = var.num_instances == 0 ? false : true
+  startup_script = var.startup_script
 
   project_id  = local.project_id
   name_prefix = "multinic"

--- a/examples/multiregion/main.tf
+++ b/examples/multiregion/main.tf
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "project_id" {
+  description = "Project ID containing managed resources"
+  type        = string
+}
+
 variable "num_instances" {
   description = "Set to 0 to reduce costs when not actively developing."
   type        = number
@@ -23,10 +28,10 @@ variable "preemptible" {
   type        = bool
   default     = true
 }
-
-variable "project_id" {
-  description = "Project ID containing managed resources"
+variable "startup_script" {
+  description = "Startup script executed after the initilization of multinic routing.  Must be a bash script."
   type        = string
+  default     = ""
 }
 
 locals {
@@ -54,8 +59,9 @@ locals {
 module "multinic-us-west1" {
   source = "../../modules/52_regional_multinic"
 
-  num_instances = var.num_instances
-  preemptible   = var.preemptible
+  num_instances  = var.num_instances
+  preemptible    = var.preemptible
+  startup_script = var.startup_script
 
   project_id  = local.project_id
   region      = "us-west1"
@@ -81,8 +87,9 @@ module "multinic-us-west1" {
 module "multinic-us-west2" {
   source = "../../modules/52_regional_multinic"
 
-  num_instances = var.num_instances
-  preemptible   = var.preemptible
+  num_instances  = var.num_instances
+  preemptible    = var.preemptible
+  startup_script = var.startup_script
 
   project_id  = local.project_id
   region      = "us-west2"

--- a/modules/50_compute/files/startup-multinic.sh
+++ b/modules/50_compute/files/startup-multinic.sh
@@ -132,7 +132,7 @@ setup_status_api() {
   install -v -o 0 -g 0 -m 0644 "${status_file}" /var/lib/multinic/status/status.json
 
   status_unit1="$(mktemp)"
-  cat <<EOF>"${status_unit1}"
+  cat <<EOF >"${status_unit1}"
 [Unit]
 Description=hc-health auto-healing endpoint (Instance is auto-healed if this unit is stopped)
 After=network.target
@@ -152,7 +152,7 @@ EOF
   install -m 0644 -o 0 -g 0 "${status_unit1}" /etc/systemd/system/hc-health.service
 
   status_unit2="$(mktemp)"
-  cat <<EOF>"${status_unit2}"
+  cat <<EOF >"${status_unit2}"
 [Unit]
 Description=hc-traffic load-balancing endpoint (Instance is taken out of service if this unit is stopped)
 After=network.target
@@ -183,7 +183,7 @@ EOF
 install_kpanic_service() {
   local tmpfile
   tmpfile="$(mktemp)"
-  cat <<EOF>"${tmpfile}"
+  cat <<EOF >"${tmpfile}"
 [Unit]
 Description=Triggers a kernel panic 1 second after being started
 
@@ -278,7 +278,7 @@ EOF
   install -o 0 -g 0 -m 0755 "$tmpfile" /usr/sbin/policy-routing-stop
 
   svcfile="$(mktemp)"
-  cat <<EOF>"$svcfile"
+  cat <<EOF >"$svcfile"
 [Unit]
 Description=Configure Policy Routing to behave as a virtual wire
 After=network-online.target
@@ -397,5 +397,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 
 main "$@"
+
+# Execute an user-defined startup script if present, otherwise do nothing.
+curl -H "Metadata-Flavor: Google" --silent --fail http://metadata.google.internal/computeMetadata/v1/instance/attributes/startup-script-user | bash
 
 # vim:sw=2

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -62,6 +62,7 @@ resource google_compute_instance_template "multinic" {
     startup-script-config = data.template_file.startup-script-config.rendered
     # Configure  Linux Policy Routing
     startup-script-custom = file("${path.module}/files/startup-multinic.sh")
+    startup-script-user   = var.startup_script
     # Deletes the route resources
     shutdown-script       = file("${path.module}/files/shutdown-multinic.sh")
   }

--- a/modules/50_compute/variables.tf
+++ b/modules/50_compute/variables.tf
@@ -159,3 +159,9 @@ variable "labels" {
     role = "multinic-router"
   }
 }
+
+variable "startup_script" {
+  description = "Startup script executed after the initilization of multinic routing.  Must be a bash script."
+  type        = string
+  default     = ""
+}

--- a/modules/52_regional_multinic/main.tf
+++ b/modules/52_regional_multinic/main.tf
@@ -25,9 +25,10 @@ locals {
 module "multinic" {
   source = "../50_compute"
 
-  num_instances = var.num_instances
-  preemptible   = var.preemptible
-  autoscale     = var.num_instances == 0 ? false : true
+  num_instances  = var.num_instances
+  preemptible    = var.preemptible
+  autoscale      = var.num_instances == 0 ? false : true
+  startup_script = var.startup_script
 
   project_id  = var.project_id
   name_prefix = "multinic-${var.region}"

--- a/modules/52_regional_multinic/variables.tf
+++ b/modules/52_regional_multinic/variables.tf
@@ -80,3 +80,9 @@ variable "service_account_email" {
   description = "The service account bound to the bridge VM instances.  Must have permission to create Route resources in both the app and core VPC networks."
   type        = string
 }
+
+variable "startup_script" {
+  description = "Startup script executed after the initilization of multinic routing.  Must be a bash script."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This patch adds an input variable to allow an user defined startup
script to execute immediately after the multinic startup script
executes.  The script must be bash and is stored in the
startup-script-user instance metadata key.

 * [x] Plumb startup_script_user var into 50_compute
 * [x] Plumb startup_script_user var into 52_regional_multinic
 * [x] Plumb startup_script_user var into examples

Resolves: #40
