### PR TITLE
(#43) Set instance group size to 0 when num_instances=0

### DIFF
--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -14,6 +14,7 @@
 
 locals {
   tags = concat(list("multinic-router"), var.tags)
+  mig_target_size = var.num_instances == 0 ? 0 : null
 }
 
 module "startup-script-lib" {
@@ -102,7 +103,7 @@ resource "google_compute_instance_group_manager" "multinic" {
   # See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager#target_size
   # This value should always be explicitly set unless this resource is attached
   # to an autoscaler, in which case it should never be set.
-  target_size = var.autoscale ? null : var.num_instances
+  target_size = var.autoscale ? local.mig_target_size : var.num_instances
 
   named_port {
     name = "hc-health"


### PR DESCRIPTION
Without this patch, `terraform apply -var num_instances=0` does not
scale down to zero when auto scaling is enabled.

See: #43
