### PR TITLE
(#38) Update project and vpc modules to TF 13

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,3 +1,11 @@
+Terraform 0.13 Upgrade
+===
+
+ 1. Use Terraform 0.12 to init, plan, and apply version 3.x of this module.
+ 2. Use Terraform 0.13 to init, plan, and apply the same 3.x version.
+ 3. Update this module to version 4.x.
+ 4. Use Terraform 0.13 to init, plan, and apply 4.x.
+
 Upgrade Procedure
 ===
 

--- a/examples/multiregion/main.tf
+++ b/examples/multiregion/main.tf
@@ -65,6 +65,7 @@ module "multinic-us-west1-v3" {
   num_instances  = var.num_instances
   preemptible    = var.preemptible
   startup_script = var.startup_script
+  autoscale      = var.num_instances == 0 ? false : true
 
   project_id  = local.project_id
   region      = "us-west1"
@@ -96,6 +97,7 @@ module "multinic-us-west2-v3" {
   num_instances  = var.num_instances
   preemptible    = var.preemptible
   startup_script = var.startup_script
+  autoscale      = var.num_instances == 0 ? false : true
 
   project_id  = local.project_id
   region      = "us-west2"

--- a/examples/networksetup/versions.tf
+++ b/examples/networksetup/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/10_project/main.tf
+++ b/modules/10_project/main.tf
@@ -14,7 +14,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 9.2"
+  version = "~> 10.0"
 
   name                    = var.project_name
   random_project_id       = true

--- a/modules/10_project/main.tf
+++ b/modules/10_project/main.tf
@@ -14,7 +14,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 8.0"
+  version = "~> 9.2"
 
   name                    = var.project_name
   random_project_id       = true

--- a/modules/20_vpc/main.tf
+++ b/modules/20_vpc/main.tf
@@ -18,7 +18,7 @@
 /** Manage the VPC network */
 module "vpc" {
   source  = "terraform-google-modules/network/google//modules/vpc"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   project_id              = var.project_id
   network_name            = var.network_name

--- a/modules/20_vpc/main.tf
+++ b/modules/20_vpc/main.tf
@@ -18,7 +18,7 @@
 /** Manage the VPC network */
 module "vpc" {
   source  = "terraform-google-modules/network/google//modules/vpc"
-  version = "~> 2.0.0"
+  version = "~> 2.0"
 
   project_id              = var.project_id
   network_name            = var.network_name

--- a/modules/50_compute/main.tf
+++ b/modules/50_compute/main.tf
@@ -30,7 +30,7 @@ module "startup-script-lib" {
 }
 
 data "template_file" "startup-script-config" {
-  template = "${file("${path.module}/templates/startup-script-config.tpl")}"
+  template = file("${path.module}/templates/startup-script-config.tpl")
 }
 
 resource google_compute_instance_template "multinic" {


### PR DESCRIPTION
This patch upgrades the CFT Project Factory and Network modules for use
with Terraform 13.

Closes: #38
